### PR TITLE
Adjust sendMessage signature to match latest

### DIFF
--- a/__tests__/runtime.test.js
+++ b/__tests__/runtime.test.js
@@ -24,7 +24,7 @@ describe('browser.runtime', () => {
     const name = 'CONNECT_NAME';
     const listener = jest.fn();
     browser.runtime.connect(name).onMessage.addListener(listener);
-    browser.runtime.sendMessage({ test: 'message' }, done);
+    browser.runtime.sendMessage('id', { test: 'message' }, null, done);
     expect(listener).toHaveBeenCalledWith({ test: 'message' });
   });
   test('getURL', () => {
@@ -38,16 +38,16 @@ describe('browser.runtime', () => {
   test('sendMessage', (done) => {
     const callback = jest.fn(() => done());
     expect(jest.isMockFunction(browser.runtime.sendMessage)).toBe(true);
-    browser.runtime.sendMessage({ test: 'message' }, callback);
+    browser.runtime.sendMessage('id', { test: 'message' }, null, callback);
     expect(browser.runtime.sendMessage).toHaveBeenCalledTimes(1);
     expect(callback).toHaveBeenCalledTimes(1);
-    browser.runtime.sendMessage({ test: 'message' });
+    browser.runtime.sendMessage('id', { test: 'message' });
     expect(browser.runtime.sendMessage).toHaveBeenCalledTimes(2);
   });
   test('sendMessage listener', (done) => {
     const listener = jest.fn();
     browser.runtime.onMessage.addListener(listener);
-    browser.runtime.sendMessage({ test: 'message' }, done);
+    browser.runtime.sendMessage('id', { test: 'message' }, null, done);
     expect(listener).toHaveBeenCalledWith({ test: 'message' });
   });
   test('sendMessage promise', () => {

--- a/dist/setup.js
+++ b/dist/setup.js
@@ -81,7 +81,7 @@ var runtime = {
       disconnect: jest.fn()
     };
   }),
-  sendMessage: jest.fn(function (message, cb) {
+  sendMessage: jest.fn(function (extensionId, message, options, cb) {
     onMessageListeners.forEach(function (listener) {
       return listener(message);
     });

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -16,7 +16,7 @@ export const runtime = {
       disconnect: jest.fn(),
     };
   }),
-  sendMessage: jest.fn((message, cb) => {
+  sendMessage: jest.fn((extensionId, message, options, cb) => {
     onMessageListeners.forEach((listener) => listener(message));
     if (cb !== undefined) {
       return cb();


### PR DESCRIPTION
Chrome has adjusted this signature so when this is called with an extensionId this mock fails an error 

TypeError: cb is not a function