### PR TITLE
fix: `browser.storage` should not include unknown keys in the result

### DIFF
--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -19,32 +19,21 @@ describe('browser.storage', () => {
         test('a string key', (done) => {
           const key = 'test';
           storage.get(key, (result) => {
-            expect(result).toBeDefined();
-            expect(typeof result === 'object').toBeTruthy();
-            expect(result).toHaveProperty(key, undefined);
+            expect(result).toStrictEqual({});
             done();
           });
         });
         test('an array key', (done) => {
           const keys = ['test1', 'test2'];
           storage.get(keys, (result) => {
-            expect(result).toBeDefined();
-            expect(typeof result === 'object').toBeTruthy();
-            keys.forEach((k) => {
-              expect(result).toHaveProperty(k, undefined);
-            });
+            expect(result).toStrictEqual({});
             done();
           });
         });
         test('an object key', (done) => {
           const key = { test: [] };
           storage.get(key, (result) => {
-            expect(result).toBeDefined();
-            expect(typeof result === 'object').toBeTruthy();
-            Object.keys(key).forEach((k) => {
-              expect(result).toHaveProperty(k);
-              expect(result[k]).toEqual(key[k]);
-            });
+            expect(result).toStrictEqual({ test: [] });
             done();
           });
         });
@@ -71,8 +60,8 @@ describe('browser.storage', () => {
         const key = 'key';
         return expect(storage.get(key)).resolves.toEqual({ key: undefined });
       });
-      test('getBytesInUse', (done) => {
-        const callback = jest.fn(() => done());
+      test('getBytesInUse', () => {
+        const callback = jest.fn();
         expect(jest.isMockFunction(storage.getBytesInUse)).toBe(true);
         storage.getBytesInUse('key', callback);
         expect(storage.getBytesInUse).toHaveBeenCalledTimes(1);
@@ -81,8 +70,8 @@ describe('browser.storage', () => {
       test('getBytesInUse promise', () => {
         return expect(storage.getBytesInUse('key')).resolves.toBe(0);
       });
-      test('set', (done) => {
-        const callback = jest.fn(() => done());
+      test('set', () => {
+        const callback = jest.fn();
         expect(jest.isMockFunction(storage.set)).toBe(true);
         storage.set({ key: 'foo' }, callback);
         expect(storage.set).toHaveBeenCalledTimes(1);
@@ -91,8 +80,8 @@ describe('browser.storage', () => {
       test('set promise', () => {
         return expect(storage.set(1)).resolves.toBeUndefined();
       });
-      test('remove', (done) => {
-        const callback = jest.fn(() => done());
+      test('remove', () => {
+        const callback = jest.fn();
         expect(jest.isMockFunction(storage.remove)).toBe(true);
         storage.remove('key', callback);
         expect(storage.remove).toHaveBeenCalledTimes(1);
@@ -101,8 +90,8 @@ describe('browser.storage', () => {
       test('remove promise', () => {
         return expect(storage.remove(['foo', 'bar'])).resolves.toBeUndefined();
       });
-      test('clear', (done) => {
-        const callback = jest.fn(() => done());
+      test('clear', () => {
+        const callback = jest.fn();
         expect(jest.isMockFunction(browser.storage.sync.clear)).toBe(true);
         storage.clear(callback);
         expect(storage.clear).toHaveBeenCalledTimes(1);
@@ -120,24 +109,16 @@ describe('browser.storage', () => {
         storage.set({ key: 'value', foo: 'bar', foo2: 'bar2' }, () => {
           // get 'key'
           storage.get(['key'], (result) => {
-            expect(result).toBeDefined();
-            expect(typeof result === 'object').toBeTruthy();
-            expect(result).toHaveProperty('key', 'value');
-            expect(result).not.toHaveProperty('foo');
-            expect(result).not.toHaveProperty('foo2');
+            expect(result).toStrictEqual({ key: 'value' });
             // remove 'key'
             storage.remove('key', () => {
               // get all values
               storage.get(null, (result) => {
-                expect(result).toHaveProperty('key', undefined);
-                expect(result).toHaveProperty('foo', 'bar');
-                expect(result).toHaveProperty('foo2', 'bar2');
+                expect(result).toStrictEqual({ foo: 'bar', foo2: 'bar2' });
                 // clear values
                 storage.clear(() => {
                   storage.get(['key', 'foo', 'foo2'], (result) => {
-                    expect(result).toHaveProperty('key', undefined);
-                    expect(result).toHaveProperty('foo', undefined);
-                    expect(result).toHaveProperty('foo2', undefined);
+                    expect(result).toStrictEqual({});
                     done();
                   });
                 });

--- a/src/storage.js
+++ b/src/storage.js
@@ -1,191 +1,81 @@
 import { createEventListeners } from './createEventListeners';
 
-let syncStore = {};
-let localStore = {};
-let managedStore = {};
-let sessionStore = {};
-
 function resolveKey(key, store) {
   if (typeof key === 'string') {
-    const result = {};
-    result[key] = store[key];
-    return result;
+    if (key in store) {
+      return { key: store[key] };
+    } else {
+      return {};
+    }
   } else if (Array.isArray(key)) {
-    return key.reduce((acc, curr) => {
-      acc[curr] = store[curr];
-      return acc;
-    }, {});
+    return key.reduce(
+      (acc, currKey) => ({
+        ...acc,
+        ...resolveKey(currKey, store),
+      }),
+      {}
+    );
   } else if (typeof key === 'object') {
-    return Object.keys(key).reduce((acc, curr) => {
-      acc[curr] = store[curr] || key[curr];
-      return acc;
-    }, {});
+    return Object.entries(key).reduce(
+      (acc, [currKey, fallbackValue]) => ({
+        ...acc,
+        [currKey]: fallbackValue,
+        ...resolveKey(currKey, store),
+      }),
+      {}
+    );
   }
   throw new Error('Wrong key given');
 }
 
+function mockStore() {
+  const store = {};
+
+  return {
+    get: jest.fn((id, cb) => {
+      const result =
+        id === null || id === undefined ? store : resolveKey(id, store);
+      if (cb !== undefined) {
+        return cb(result);
+      }
+      return Promise.resolve(result);
+    }),
+    getBytesInUse: jest.fn((id, cb) => {
+      if (cb !== undefined) {
+        return cb(0);
+      }
+      return Promise.resolve(0);
+    }),
+    set: jest.fn((payload, cb) => {
+      Object.keys(payload).forEach((key) => (store[key] = payload[key]));
+      if (cb !== undefined) {
+        return cb();
+      }
+      return Promise.resolve();
+    }),
+    remove: jest.fn((id, cb) => {
+      const keys = typeof id === 'string' ? [id] : id;
+      keys.forEach((key) => delete store[key]);
+      if (cb !== undefined) {
+        return cb();
+      }
+      return Promise.resolve();
+    }),
+    clear: jest.fn((cb) => {
+      Object.keys(store).forEach((key) => delete store[key]);
+      if (cb !== undefined) {
+        return cb();
+      }
+      return Promise.resolve();
+    }),
+    onChanged: createEventListeners(),
+  };
+}
+
 export const storage = {
-  sync: {
-    get: jest.fn((id, cb) => {
-      const result =
-        id === null || id === undefined ? syncStore : resolveKey(id, syncStore);
-      if (cb !== undefined) {
-        return cb(result);
-      }
-      return Promise.resolve(result);
-    }),
-    getBytesInUse: jest.fn((id, cb) => {
-      if (cb !== undefined) {
-        return cb(0);
-      }
-      return Promise.resolve(0);
-    }),
-    set: jest.fn((payload, cb) => {
-      Object.keys(payload).forEach((key) => (syncStore[key] = payload[key]));
-      if (cb !== undefined) {
-        return cb();
-      }
-      return Promise.resolve();
-    }),
-    remove: jest.fn((id, cb) => {
-      const keys = typeof id === 'string' ? [id] : id;
-      keys.forEach((key) => delete syncStore[key]);
-      if (cb !== undefined) {
-        return cb();
-      }
-      return Promise.resolve();
-    }),
-    clear: jest.fn((cb) => {
-      syncStore = {};
-      if (cb !== undefined) {
-        return cb();
-      }
-      return Promise.resolve();
-    }),
-    onChanged: createEventListeners(),
-  },
-  local: {
-    get: jest.fn((id, cb) => {
-      const result =
-        id === null || id === undefined
-          ? localStore
-          : resolveKey(id, localStore);
-      if (cb !== undefined) {
-        return cb(result);
-      }
-      return Promise.resolve(result);
-    }),
-    getBytesInUse: jest.fn((id, cb) => {
-      if (cb !== undefined) {
-        return cb(0);
-      }
-      return Promise.resolve(0);
-    }),
-    set: jest.fn((payload, cb) => {
-      Object.keys(payload).forEach((key) => (localStore[key] = payload[key]));
-      if (cb !== undefined) {
-        return cb();
-      }
-      return Promise.resolve();
-    }),
-    remove: jest.fn((id, cb) => {
-      const keys = typeof id === 'string' ? [id] : id;
-      keys.forEach((key) => delete localStore[key]);
-      if (cb !== undefined) {
-        return cb();
-      }
-      return Promise.resolve();
-    }),
-    clear: jest.fn((cb) => {
-      localStore = {};
-      if (cb !== undefined) {
-        return cb();
-      }
-      return Promise.resolve();
-    }),
-    onChanged: createEventListeners(),
-  },
-  session: {
-    get: jest.fn((id, cb) => {
-      const result =
-        id === null || id === undefined
-          ? localStore
-          : resolveKey(id, localStore);
-      if (cb !== undefined) {
-        return cb(result);
-      }
-      return Promise.resolve(result);
-    }),
-    getBytesInUse: jest.fn((id, cb) => {
-      if (cb !== undefined) {
-        return cb(0);
-      }
-      return Promise.resolve(0);
-    }),
-    set: jest.fn((payload, cb) => {
-      Object.keys(payload).forEach((key) => (localStore[key] = payload[key]));
-      if (cb !== undefined) {
-        return cb();
-      }
-      return Promise.resolve();
-    }),
-    remove: jest.fn((id, cb) => {
-      const keys = typeof id === 'string' ? [id] : id;
-      keys.forEach((key) => delete localStore[key]);
-      if (cb !== undefined) {
-        return cb();
-      }
-      return Promise.resolve();
-    }),
-    clear: jest.fn((cb) => {
-      localStore = {};
-      if (cb !== undefined) {
-        return cb();
-      }
-      return Promise.resolve();
-    }),
-    onChanged: createEventListeners(),
-  },
-  managed: {
-    get: jest.fn((id, cb) => {
-      const result =
-        id === null || id === undefined
-          ? managedStore
-          : resolveKey(id, managedStore);
-      if (cb !== undefined) {
-        return cb(result);
-      }
-      return Promise.resolve(result);
-    }),
-    getBytesInUse: jest.fn((id, cb) => {
-      if (cb !== undefined) {
-        return cb(0);
-      }
-      return Promise.resolve(0);
-    }),
-    set: jest.fn((payload, cb) => {
-      Object.keys(payload).forEach((key) => (managedStore[key] = payload[key]));
-      if (cb !== undefined) {
-        return cb();
-      }
-      return Promise.resolve();
-    }),
-    remove: jest.fn((id, cb) => {
-      const keys = typeof id === 'string' ? [id] : id;
-      keys.forEach((key) => delete managedStore[key]);
-      if (cb !== undefined) {
-        return cb();
-      }
-      return Promise.resolve();
-    }),
-    clear: jest.fn((cb) => {
-      managedStore = {};
-      if (cb !== undefined) {
-        return cb();
-      }
-      return Promise.resolve();
-    }),
-    onChanged: createEventListeners(),
-  },
+  sync: mockStore(),
+  local: mockStore(),
+  session: mockStore(),
+  managed: mockStore(),
   onChanged: createEventListeners(),
 };


### PR DESCRIPTION
As described in the [documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/get), when the key is not present in the storage, it should be completely missing from the `.get()` result as well. The current mock implementation was returning the key in the result with `undefined` value.

Also the lastly added session storage mock was sharing data with local storage.