### PR TITLE
test(storage): regression test for remove() deleting keys entirely (#20)

### DIFF
--- a/.changeset/storage-remove-regression-test.md
+++ b/.changeset/storage-remove-regression-test.md
@@ -1,0 +1,4 @@
+---
+---
+
+Add a regression test confirming `storage.*.remove()` deletes keys entirely instead of leaving them set to `undefined` (#20).

--- a/__tests__/storage.test.js
+++ b/__tests__/storage.test.js
@@ -127,6 +127,13 @@ describe('browser.storage', () => {
           });
         });
       });
+      test('remove deletes the key entirely', async () => {
+        await storage.set({ hi: 1 });
+        await storage.remove('hi');
+        const result = await storage.get(null);
+        expect(result).toStrictEqual({});
+        expect('hi' in result).toBe(false);
+      });
       test('onChanged', () => {
         const callback = jest.fn();
         expect(jest.isMockFunction(storage.onChanged.addListener)).toBe(true);


### PR DESCRIPTION
## Summary

Issue #20 reported that `StorageArea.remove()` left the key set to `undefined` instead of deleting it.

The current implementation (`src/storage.js`) already uses `delete store[key]`, so the key is removed entirely. The issue's repro also used a non-existent `delete()` method (the real method is `remove()`).

This adds a focused regression test asserting the key is fully gone after `remove()` (not present as `undefined`), across all four storage areas.

## Test plan

- `npx jest storage` passes, including the new `remove deletes the key entirely` test.

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)