### PR TITLE
feat(contextMenus): add contextMenus/menus API mock (#11)

### DIFF
--- a/.changeset/context-menus-api.md
+++ b/.changeset/context-menus-api.md
@@ -1,0 +1,5 @@
+---
+'jest-webextension-mock': minor
+---
+
+Add a mock for the `contextMenus` API (also exposed as `menus` for Firefox parity): `create`, `update`, `remove`, `removeAll`, `refresh`, `getTargetElement`, the `ACTION_MENU_TOP_LEVEL_LIMIT` constant, and the `onClicked`/`onShown`/`onHidden` events (#11).

--- a/__tests__/contextMenus.test.js
+++ b/__tests__/contextMenus.test.js
@@ -1,0 +1,113 @@
+describe('chrome.contextMenus', () => {
+  beforeEach(() => {
+    chrome.contextMenus.create.mockClear();
+    chrome.contextMenus.update.mockClear();
+    chrome.contextMenus.remove.mockClear();
+    chrome.contextMenus.removeAll.mockClear();
+    chrome.contextMenus.refresh.mockClear();
+  });
+
+  test('is aliased as menus for Firefox', () => {
+    expect(chrome.menus).toBe(chrome.contextMenus);
+    expect(browser.menus).toBe(browser.contextMenus);
+  });
+
+  test('exposes ACTION_MENU_TOP_LEVEL_LIMIT', () => {
+    expect(typeof chrome.contextMenus.ACTION_MENU_TOP_LEVEL_LIMIT).toBe(
+      'number'
+    );
+  });
+
+  describe('create', () => {
+    test('is a mock function', () => {
+      expect(jest.isMockFunction(chrome.contextMenus.create)).toBe(true);
+    });
+    test('returns the provided id', () => {
+      const id = chrome.contextMenus.create({ id: 'my-item', title: 'Hi' });
+      expect(id).toBe('my-item');
+    });
+    test('generates an id when none is provided', () => {
+      const id = chrome.contextMenus.create({ title: 'Hi' });
+      expect(typeof id).toBe('string');
+      expect(id.length).toBeGreaterThan(0);
+    });
+    test('invokes the callback when given', () => {
+      const callback = jest.fn();
+      chrome.contextMenus.create({ title: 'Hi' }, callback);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('update', () => {
+    test('is a mock function', () => {
+      expect(jest.isMockFunction(chrome.contextMenus.update)).toBe(true);
+    });
+    test('accepts a callback', () => {
+      const callback = jest.fn();
+      chrome.contextMenus.update('id', { title: 'New' }, callback);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+    test('returns a promise', () => {
+      return expect(
+        chrome.contextMenus.update('id', { title: 'New' })
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('remove', () => {
+    test('is a mock function', () => {
+      expect(jest.isMockFunction(chrome.contextMenus.remove)).toBe(true);
+    });
+    test('accepts a callback', () => {
+      const callback = jest.fn();
+      chrome.contextMenus.remove('id', callback);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+    test('returns a promise', () => {
+      return expect(chrome.contextMenus.remove('id')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('removeAll', () => {
+    test('is a mock function', () => {
+      expect(jest.isMockFunction(chrome.contextMenus.removeAll)).toBe(true);
+    });
+    test('accepts a callback', () => {
+      const callback = jest.fn();
+      chrome.contextMenus.removeAll(callback);
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+    test('returns a promise', () => {
+      return expect(chrome.contextMenus.removeAll()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('refresh (Firefox)', () => {
+    test('returns a promise', () => {
+      return expect(chrome.contextMenus.refresh()).resolves.toBeUndefined();
+    });
+  });
+
+  ['onClicked', 'onShown', 'onHidden'].forEach((event) => {
+    describe(event, () => {
+      const listener = () => {};
+
+      afterEach(() => {
+        chrome.contextMenus[event].removeListener(listener);
+      });
+
+      test('addListener / hasListener / removeListener', () => {
+        const e = chrome.contextMenus[event];
+        expect(jest.isMockFunction(e.addListener)).toBe(true);
+
+        expect(e.hasListeners()).toBe(false);
+        e.addListener(listener);
+        expect(e.hasListener(listener)).toBe(true);
+        expect(e.hasListeners()).toBe(true);
+
+        e.removeListener(listener);
+        expect(e.hasListener(listener)).toBe(false);
+      });
+    });
+  });
+});

--- a/src/contextMenus.js
+++ b/src/contextMenus.js
@@ -1,0 +1,37 @@
+import { createEventListeners } from './createEventListeners';
+
+const cbOrPromise = (cb, value) => {
+  if (cb !== undefined) {
+    return cb(value);
+  }
+
+  return Promise.resolve(value);
+};
+
+let generatedId = 0;
+
+const create = (createProperties, cb) => {
+  const id =
+    createProperties && createProperties.id !== undefined
+      ? createProperties.id
+      : `generated-id-${++generatedId}`;
+
+  if (typeof cb === 'function') {
+    cb();
+  }
+
+  return id;
+};
+
+export const contextMenus = {
+  ACTION_MENU_TOP_LEVEL_LIMIT: 6,
+  create: jest.fn(create),
+  update: jest.fn((id, updateProperties, cb) => cbOrPromise(cb)),
+  remove: jest.fn((menuItemId, cb) => cbOrPromise(cb)),
+  removeAll: jest.fn((cb) => cbOrPromise(cb)),
+  refresh: jest.fn((cb) => cbOrPromise(cb)),
+  getTargetElement: jest.fn(() => null),
+  onClicked: createEventListeners(),
+  onShown: createEventListeners(),
+  onHidden: createEventListeners(),
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import { alarms } from './alarms';
 import { browserAction } from './browserAction';
 import { commands } from './commands';
+import { contextMenus } from './contextMenus';
 import { downloads } from './downloads';
 import { extension } from './extension';
 import { geckoProfiler } from './geckoProfiler';
@@ -24,6 +25,8 @@ const chrome = {
   alarms,
   browserAction,
   commands,
+  contextMenus,
+  menus: contextMenus, // Firefox exposes the same API as `menus`
   downloads,
   extension,
   geckoProfiler,


### PR DESCRIPTION
## Summary

Closes #11. Adds a mock for the [`contextMenus`](https://developer.chrome.com/docs/extensions/reference/api/contextMenus) API, also exposed as [`menus`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/menus) for Firefox parity (same object reference).

Surface:
- `create` — returns the menu item id synchronously (matching the real API), generating one when not supplied; invokes an optional callback.
- `update`, `remove`, `removeAll`, `refresh` — callback/promise dual pattern.
- `getTargetElement` — returns `null` (Firefox).
- `ACTION_MENU_TOP_LEVEL_LIMIT` constant.
- `onClicked`, `onShown`, `onHidden` — stateful listeners via `createEventListeners()`.

`chrome.menus === chrome.contextMenus`.

## Test plan

- `npx jest contextMenus` — 19 tests pass.
- Full suite: 288 tests pass.
- Integration runner (passbolt, copyguard, tabli) — all pass against the packed build.
- Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)